### PR TITLE
Add genisys-firstboot.service for launching first boot script

### DIFF
--- a/genisys/main.py
+++ b/genisys/main.py
@@ -10,9 +10,10 @@ from genisys.modules.dns import Dnsmasq
 from genisys.modules.ftp import VsftpdModule
 from genisys.modules.os_file_download import OSDownload
 from genisys.modules.syslinux import Syslinux
+from genisys.modules.firstboot import Service
 import genisys.config_parser as cp
 
-MODULES = [OSDownload, Netplan, Preseed, Nat, KernelParameter, Dnsmasq, VsftpdModule, Syslinux]
+MODULES = [OSDownload, Netplan, Preseed, Nat, KernelParameter, Dnsmasq, VsftpdModule, Syslinux, Service]
 
 def validate(file):
     """Display validation errors to the user."""

--- a/genisys/main.py
+++ b/genisys/main.py
@@ -13,7 +13,17 @@ from genisys.modules.syslinux import Syslinux
 from genisys.modules.firstboot import Service
 import genisys.config_parser as cp
 
-MODULES = [OSDownload, Netplan, Preseed, Nat, KernelParameter, Dnsmasq, VsftpdModule, Syslinux, Service]
+MODULES = [
+    OSDownload,
+    Netplan,
+    Preseed,
+    Nat,
+    KernelParameter,
+    Dnsmasq,
+    VsftpdModule,
+    Syslinux,
+    Service
+]
 
 def validate(file):
     """Display validation errors to the user."""

--- a/genisys/modules/firstboot.py
+++ b/genisys/modules/firstboot.py
@@ -5,14 +5,16 @@ from genisys.config_parser import YAMLParser
 
 class Service(Module):
     """Installs the firstboot systemd service file to the ftp dir to be downloaded by clients"""
+    SERVICE_NAME = "genisys-firstboot.service"
+
     def __init__(self: Self, config: YAMLParser):
         self.config = {}
         self.config["path"] = config.get_section("Network").get("ftp", {}).get("directory")
 
     def install_location(self: Self) -> Path:
-        return Path(self.config["path"])
+        return Path(self.config["path"]) / "first-boot" / self.SERVICE_NAME
 
     def generate(self: Self):
-        template_path = Path(__file__).parent / "templates" / "genisys-firstboot.service"
+        template_path = Path(__file__).parent / "templates" / self.SERVICE_NAME
         with template_path.open("r") as fd:
             return fd.read()

--- a/genisys/modules/firstboot.py
+++ b/genisys/modules/firstboot.py
@@ -1,9 +1,10 @@
-from genisys.modules.base import Module
-from genisys.config_parser import YAMLParser
 from pathlib import Path
 from typing_extensions import Self
+from genisys.modules.base import Module
+from genisys.config_parser import YAMLParser
 
 class Service(Module):
+    """Installs the firstboot systemd service file to the ftp dir to be downloaded by clients"""
     def __init__(self: Self, config: YAMLParser):
         self.config = {}
         self.config["path"] = config.get_section("Network").get("ftp", {}).get("directory")

--- a/genisys/modules/firstboot.py
+++ b/genisys/modules/firstboot.py
@@ -1,0 +1,17 @@
+from genisys.modules.base import Module
+from genisys.config_parser import YAMLParser
+from pathlib import Path
+from typing_extensions import Self
+
+class Service(Module):
+    def __init__(self: Self, config: YAMLParser):
+        self.config = {}
+        self.config["path"] = config.get_section("Network").get("ftp", {}).get("directory")
+
+    def install_location(self: Self) -> Path:
+        return Path(self.config["path"])
+
+    def generate(self: Self):
+        template_path = Path(__file__).parent / "templates" / "genisys-firstboot.service"
+        with template_path.open("r") as fd:
+            return fd.read()

--- a/genisys/templates/genisys-firstboot.service
+++ b/genisys/templates/genisys-firstboot.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Run user script on Genisys client first boot
+ConditionFileIsExecutable=/first-boot/entrypoint
+Wants=network-online.target
+Requires=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/first-boot/entrypoint
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
Adds a SystemD service unit file to the templates dir to be packaged with the application. Service file requires network to be enabled, allowing the majority of admin tasks to be complete. Also requires an executable file to be placed at /first-boot/entrypoint.